### PR TITLE
Update .gitignore to ignore all _build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-/_build
+_build/


### PR DESCRIPTION
Updates .gitignore to ignore _build/ directories globally across PLaF, ensuring 'dune build' artifacts aren't accidentally tracked if ran in subdirectories